### PR TITLE
Bug fixes and correction in stream::assemble

### DIFF
--- a/crates/briefs-core/src/config.rs
+++ b/crates/briefs-core/src/config.rs
@@ -174,7 +174,7 @@ mod tests {
 
     #[test]
     fn test_save() {
-        let config = BriefsConfig::default();
+        let (_, config) = crate::utils::tests::get_mocks();
         config.save().unwrap();
 
         let saved_config = BriefsConfig::from_file(config.filepath.clone()).unwrap();

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -64,7 +64,7 @@ async fn main() {
         while let Some(StreamCommand { cmd, resp }) = rx.recv().await {
             match cmd {
                 Command::Create { title, msg } => {
-                    let new_post = post::Post::new(stream.size() as u32, title, msg);
+                    let new_post = post::Post::new(stream.nposts() as u32, title, msg);
                     if new_post.is_err() {
                         respond_with_bytes(
                             resp.unwrap(),


### PR DESCRIPTION
A uni-test was messing with the default config dir, which has been fixed. Also, stream::assemble used to populate cache with reversed order of posts from db. This meant that catchup was not working correctly. Fixes #12 